### PR TITLE
Introduce support to log messageId for delivery notifications

### DIFF
--- a/components/messagestore/Dependencies.toml
+++ b/components/messagestore/Dependencies.toml
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "java.jms"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/components/messagestore/api.bal
+++ b/components/messagestore/api.bal
@@ -19,6 +19,8 @@ import ballerina/log;
 
 # Represents a message published to a message store.
 public type Message record {
+    # The message Id
+    string id?;
     # The message payload
     byte[] payload;
     # The metadata associated with the message (e.g., Kafka message headers or JMS message properties)

--- a/components/messagestore/jms_api.bal
+++ b/components/messagestore/jms_api.bal
@@ -29,6 +29,7 @@ isolated client class JmsProducer {
 
     isolated remote function send(string topic, Message message) returns error? {
         jms:BytesMessage jmsMessage = {
+            correlationId: message.id,
             content: message.payload
         };
         check self.producer->sendTo(
@@ -73,6 +74,7 @@ isolated client class JmsConsumer {
             return;
         }
         Message message = {
+            id: receivedMsg.correlationId,
             payload: receivedMsg.content
         };
         return message;

--- a/components/messagestore/solace_api.bal
+++ b/components/messagestore/solace_api.bal
@@ -45,7 +45,10 @@ isolated client class SolaceProducer {
         // todo: Setting properties will throw an error, hence ignoring setting properties for now
         check self.producer->send(
             {topicName: topic},
-            {payload: message.payload}
+            {
+                applicationMessageId: message.id, 
+                payload: message.payload
+            }
         );
     }
 
@@ -86,6 +89,7 @@ isolated client class SolaceConsumer {
             return;
         }
         Message message = {
+            id: receivedMsg.applicationMessageId,
             payload: receivedMsg.payload
         };
         message[ORIGINAL_SOLACE_MSG] = receivedMsg;

--- a/components/websubhub-consolidator/Dependencies.toml
+++ b/components/websubhub-consolidator/Dependencies.toml
@@ -367,7 +367,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "java.jms"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/components/websubhub/Dependencies.toml
+++ b/components/websubhub/Dependencies.toml
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "java.jms"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/components/websubhub/hub_service.bal
+++ b/components/websubhub/hub_service.bal
@@ -307,6 +307,10 @@ isolated function getMessageId(http:Headers httpHeaders) returns string? {
 isolated function getHeadersMap(http:Headers httpHeaders) returns map<string[]> {
     map<string[]> headers = {};
     foreach string headerName in httpHeaders.getHeaderNames() {
+        // exclude the messageId header as it will be dealt with separately
+        if headerName == MESSAGE_ID_HEADER {
+            continue;
+        }
         var headerValues = httpHeaders.getHeaders(headerName);
         // safe to ingore the error as here we are retrieving only the available headers
         if headerValues is error {

--- a/components/websubhub/hub_service.bal
+++ b/components/websubhub/hub_service.bal
@@ -25,6 +25,8 @@ import ballerina/log;
 import ballerina/time;
 import ballerina/websubhub;
 
+const MESSAGE_ID_HEADER = "x-hub-messageId";
+
 http:Service healthCheckService = service object {
     resource function get .() returns http:Ok {
         return {
@@ -272,8 +274,9 @@ websubhub:Service hubService = @websubhub:ServiceConfig {
             topicAvailable = registeredTopicsCache.hasKey(msg.hubTopic);
         }
         if topicAvailable {
+            string? messageId = getMessageId(headers);
             map<string[]> messageHeaders = getHeadersMap(headers);
-            error? errorResponse = persist:addUpdateMessage(msg.hubTopic, msg, messageHeaders);
+            error? errorResponse = persist:addUpdateMessage(msg.hubTopic, msg, messageHeaders, messageId);
             if errorResponse is websubhub:UpdateMessageError {
                 return errorResponse;
             } else if errorResponse is error {
@@ -287,6 +290,19 @@ websubhub:Service hubService = @websubhub:ServiceConfig {
         }
     }
 };
+
+isolated function getMessageId(http:Headers httpHeaders) returns string? {
+    if !httpHeaders.hasHeader(MESSAGE_ID_HEADER) {
+        return;
+    }
+
+    var msgId = httpHeaders.getHeader(MESSAGE_ID_HEADER);
+    // safe to ingore the error as here we are retrieving only the available headers
+    if msgId is error {
+        return;
+    }
+    return msgId;
+}
 
 isolated function getHeadersMap(http:Headers httpHeaders) returns map<string[]> {
     map<string[]> headers = {};

--- a/components/websubhub/hub_service.bal
+++ b/components/websubhub/hub_service.bal
@@ -275,8 +275,8 @@ websubhub:Service hubService = @websubhub:ServiceConfig {
         }
         if topicAvailable {
             string? messageId = getMessageId(headers);
-            map<string[]> messageHeaders = getHeadersMap(headers);
-            error? errorResponse = persist:addUpdateMessage(msg.hubTopic, msg, messageHeaders, messageId);
+            map<string[]> metadata = getMetadata(headers);
+            error? errorResponse = persist:addUpdateMessage(msg.hubTopic, msg, metadata, messageId);
             if errorResponse is websubhub:UpdateMessageError {
                 return errorResponse;
             } else if errorResponse is error {
@@ -304,7 +304,7 @@ isolated function getMessageId(http:Headers httpHeaders) returns string? {
     return msgId;
 }
 
-isolated function getHeadersMap(http:Headers httpHeaders) returns map<string[]> {
+isolated function getMetadata(http:Headers httpHeaders) returns map<string[]> {
     map<string[]> headers = {};
     foreach string headerName in httpHeaders.getHeaderNames() {
         // exclude the messageId header as it will be dealt with separately

--- a/components/websubhub/modules/common/utils.bal
+++ b/components/websubhub/modules/common/utils.bal
@@ -47,6 +47,16 @@ public isolated function logRecoverableError(string msg, error? 'error = (), *lo
     log:printError(msg, 'error, keyValues = keyValues);
 }
 
+# Logs content delivery details including topic, callback URL, and optional message ID.
+#
+# + topic - Topic associated with the content delivery
+# + callback - Callback endpoint to which the content is delivered
+# + msgId - Optional message identifier for tracking the delivery
+public isolated function logContentDelivery(string topic, string callback, string? msgId) {
+    string constructedMsgId = msgId is string ? msgId : "[No Message Id]";
+    log:printDebug("Message delivered", topic = topic, callback = callback, messageId = constructedMsgId);
+}
+
 # Extracts `http:RetryConfig` from the provided `RetryConfig`.
 #
 # + config - Optional retry configuration used to construct the `http:RetryConfig`

--- a/components/websubhub/modules/common/utils.bal
+++ b/components/websubhub/modules/common/utils.bal
@@ -53,7 +53,7 @@ public isolated function logRecoverableError(string msg, error? 'error = (), *lo
 # + callback - Callback endpoint to which the content is delivered
 # + msgId - Optional message identifier for tracking the delivery
 public isolated function logContentDelivery(string topic, string callback, string? msgId) {
-    string constructedMsgId = msgId is string ? msgId : "[No Message Id]";
+    string constructedMsgId = msgId ?: "[No Message Id]";
     log:printDebug("Message delivered", topic = topic, callback = callback, messageId = constructedMsgId);
 }
 

--- a/components/websubhub/modules/persistence/persistence.bal
+++ b/components/websubhub/modules/persistence/persistence.bal
@@ -55,14 +55,14 @@ isolated function updateHubState(StateUpdateEvent message) returns error? {
     }
 }
 
-public isolated function addUpdateMessage(string topicName, websubhub:UpdateMessage message, map<string|string[]>? metadata = ())
+public isolated function addUpdateMessage(string topicName, websubhub:UpdateMessage message, map<string|string[]>? metadata = (), string? messageId = ())
     returns error? {
     json jsonData = <json>message.content;
     byte[] payload = jsonData.toJsonString().toBytes();
-    check produceMessage(topicName, payload, metadata);
+    check produceMessage(topicName, payload, metadata, messageId);
 }
 
-isolated function produceMessage(string topic, byte[] payload, map<string|string[]>? metadata = ()) returns error? {
-    store:Message message = {payload, metadata};
+isolated function produceMessage(string topic, byte[] payload, map<string|string[]>? metadata = (), string? messageId = ()) returns error? {
+    store:Message message = {id: messageId, payload, metadata};
     return (check conn:getMessageProducer(topic))->send(topic, message);
 }

--- a/components/websubhub/websub_subscribers.bal
+++ b/components/websubhub/websub_subscribers.bal
@@ -233,7 +233,23 @@ isolated function constructContentDistMsg(store:Message message) returns websubh
     websubhub:ContentDistributionMessage distributionMsg = {
         content: payload,
         contentType: mime:APPLICATION_JSON,
-        headers: message.metadata
+        headers: constructDeliveryHeaders(message)
     };
     return distributionMsg;
+}
+
+isolated function constructDeliveryHeaders(store:Message message) returns map<string|string[]>? {
+    string? messageId = message.id;
+    if messageId is () {
+        return message.metadata;
+    }
+
+    map<string|string[]>? metadata = message.metadata;
+    if metadata is () {
+        return {
+            MESSAGE_ID_HEADER: messageId
+        };
+    }
+    metadata[MESSAGE_ID_HEADER] = messageId;
+    return metadata;
 }

--- a/components/websubhub/websub_subscribers.bal
+++ b/components/websubhub/websub_subscribers.bal
@@ -121,6 +121,7 @@ isolated function pollForNewUpdates(string subscriberId, websubhub:VerifiedSubsc
                 check consumerEp->nack(message);
                 check result;
             } else {
+                common:logContentDelivery(topic, subscription.hubCallback, message.id);
                 check consumerEp->ack(message);
             }
         }

--- a/components/websubhub/websub_subscribers.bal
+++ b/components/websubhub/websub_subscribers.bal
@@ -247,9 +247,9 @@ isolated function constructDeliveryHeaders(store:Message message) returns map<st
     map<string|string[]>? metadata = message.metadata;
     if metadata is () {
         return {
-            MESSAGE_ID_HEADER: messageId
+            "x-hub-messageId": messageId
         };
     }
-    metadata[MESSAGE_ID_HEADER] = messageId;
+    metadata["x-hub-messageId"] = messageId;
     return metadata;
 }


### PR DESCRIPTION
## Purpose
> $subject

Fixes: https://github.com/wso2/product-integrator-websubhub/issues/59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional message IDs can be provided, stored, and propagated end-to-end (including JMS and Solace) for improved correlation.
  * Publish/update flows extract an optional message ID header; delivery logging now includes that ID for visibility.
  * Delivery headers and delivery logging ensure a message ID is included when available.

* **Chores**
  * Bumped Java JMS connector dependency to 1.2.1 across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->