### PR TITLE
Externalize Solace queue configurations

### DIFF
--- a/components/messagestore/Dependencies.toml
+++ b/components/messagestore/Dependencies.toml
@@ -400,9 +400,10 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "solace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerinai", name = "observe"}
 ]
 modules = [
 	{org = "xlibb", packageName = "solace", moduleName = "solace"}

--- a/components/messagestore/messagestore.bal
+++ b/components/messagestore/messagestore.bal
@@ -53,18 +53,19 @@ public isolated function createProducer(string clientId, Config store) returns a
 # + topic - The topic from which the consumer should received events for
 # + defaultConsumerId - The default consumer Id which is associated with the user. This configuration will have different semantics for different message stores
 # + store - The message store configurations
+# + systemConsumer - Flag to indicate whether this is a system consumer
 # + meta - The meta data required to resolve the consumer configurations
 # + return - A `store:Consumer` for a specific message store, or else return an `error` if the operation fails
-public isolated function createConsumer(string topic, string defaultConsumerId, Config store, record {} meta = {}) returns api:Consumer|error {
+public isolated function createConsumer(string topic, string defaultConsumerId, Config store, boolean systemConsumer = false, record {} meta = {}) returns api:Consumer|error {
     var {kafka, solace, jms} = store;
     if kafka is kafka:Config {
-        return kafka:createConsumer(defaultConsumerId, topic, kafka, meta);
+        return kafka:createConsumer(defaultConsumerId, topic, kafka, systemConsumer, meta);
     }
     if solace is solace:Config {
-        return solace:createConsumer(defaultConsumerId, solace, meta);
+        return solace:createConsumer(defaultConsumerId, solace, systemConsumer, meta);
     }
     if jms is jms:Config {
-        return jms:createConsumer(topic, defaultConsumerId, jms, meta);
+        return jms:createConsumer(topic, defaultConsumerId, jms, systemConsumer, meta);
     }
     return error("Error occurred while reading the message store configurations when creating the store consumer");
 }

--- a/components/messagestore/modules/api/api.bal
+++ b/components/messagestore/modules/api/api.bal
@@ -117,20 +117,22 @@ public isolated client class Administrator {
     # Creates a new topic in the message store.
     #
     # + topic - Name of the topic to be created
+    # + systemTopic - Flag to notify whether this is a system topic
     # + meta - The meta data required to resolve the consumer configurations
     # + return - `TopicExists` if the topic already exists, `error?` for other errors,
     # or `()` on success
-    isolated remote function createTopic(string topic, record {} meta = {}) returns TopicExists|error? {
+    isolated remote function createTopic(string topic, boolean systemTopic = false, record {} meta = {}) returns TopicExists|error? {
         return;
     }
 
     # Deletes an existing topic from the message store.
     #
     # + topic - Name of the topic to be deleted
+    # + systemTopic - Flag to notify whether this is a system topic
     # + meta - The meta data required to resolve the consumer configurations
     # + return - `TopicNotFound` if the topic does not exist, `error?` for other errors,
     # or `()` on success
-    isolated remote function deleteTopic(string topic, record {} meta = {}) returns TopicNotFound|error? {
+    isolated remote function deleteTopic(string topic, boolean systemTopic = false, record {} meta = {}) returns TopicNotFound|error? {
         return;
     }
 
@@ -138,10 +140,11 @@ public isolated client class Administrator {
     #
     # + topic - The topic to subscribe to
     # + subscriberId - Unique identifier of the subscriber
+    # + systemSubscriber - Flag to notify whether this is a system subscriber
     # + meta - The meta data required to resolve the consumer configurations
     # + return - `SubscriptionExists` if the subscription already exists, `error?` for other
     # errors, or `()` on success
-    isolated remote function createSubscription(string topic, string subscriberId, record {} meta = {}) returns SubscriptionExists|error? {
+    isolated remote function createSubscription(string topic, string subscriberId, boolean systemSubscriber = false, record {} meta = {}) returns SubscriptionExists|error? {
         return;
     }
 
@@ -149,10 +152,11 @@ public isolated client class Administrator {
     #
     # + topic - The topic associated with the subscription
     # + subscriberId - Unique identifier of the subscriber
+    # + systemSubscriber - Flag to notify whether this is a system subscriber
     # + meta - The meta data required to resolve the consumer configurations
     # + return - `SubscriptionNotFound` if the subscription does not exist, `error?` for
     # other errors, or `()` on success
-    isolated remote function deleteSubscription(string topic, string subscriberId, record {} meta = {}) returns SubscriptionNotFound|error? {
+    isolated remote function deleteSubscription(string topic, string subscriberId, boolean systemSubscriber = false, record {} meta = {}) returns SubscriptionNotFound|error? {
         return;
     }
 

--- a/components/messagestore/modules/jms/consumer.bal
+++ b/components/messagestore/modules/jms/consumer.bal
@@ -85,12 +85,13 @@ isolated client class Consumer {
 # Initialize a consumer for JMS message store.
 #
 # + topic - The JMS topic to which the consumer should received events for
-# + subscriberName - The JMS durable subscriber to which the messages should be received
+# + defaultSubscriberId - The JMS durable subscriber Id to which the messages should be received
 # + config - The JMS connection configurations
+# + systemConsumer - Flag to indicate whether this is a system consumer
 # + meta - The meta data required to resolve the consumer configurations
 # + return - A `store:Consumer` for Kafka message store, or else return an `error` if the operation fails
-public isolated function createConsumer(string topic, string subscriberName, Config config,
-        record {} meta = {}) returns api:Consumer|error {
+public isolated function createConsumer(string topic, string defaultSubscriberId, Config config,
+        boolean systemConsumer = false, record {} meta = {}) returns api:Consumer|error {
     jms:ConnectionConfiguration connectionConfig = {
         initialContextFactory: config.initialContextFactory,
         providerUrl: config.providerUrl,
@@ -105,5 +106,6 @@ public isolated function createConsumer(string topic, string subscriberName, Con
     if dlqTopic is string {
         check initJmsDlqProducer(config);
     }
+    string subscriberName = string `consumer-${defaultSubscriberId}`;
     return new Consumer(session, config.consumer, topic, subscriberName);
 }

--- a/components/messagestore/modules/jms/consumer.bal
+++ b/components/messagestore/modules/jms/consumer.bal
@@ -106,6 +106,6 @@ public isolated function createConsumer(string topic, string defaultSubscriberId
     if dlqTopic is string {
         check initJmsDlqProducer(config);
     }
-    string subscriberName = string `consumer-${defaultSubscriberId}`;
+    string subscriberName = systemConsumer ? defaultSubscriberId : string `consumer-${defaultSubscriberId}`;
     return new Consumer(session, config.consumer, topic, subscriberName);
 }

--- a/components/messagestore/modules/kafka/consumer.bal
+++ b/components/messagestore/modules/kafka/consumer.bal
@@ -168,7 +168,7 @@ isolated client class Consumer {
 # + return - A `store:Consumer` for Kafka message store, or else return an `error` if the operation fails
 public isolated function createConsumer(string groupId, string topic, Config config, boolean systemConsumer, record {} meta = {}) returns api:Consumer|error {
 
-    string consumerGroup = check resolveConsumerGroup(groupId, meta);
+    string consumerGroup = systemConsumer ? groupId : check resolveConsumerGroup(groupId, meta);
     int[]? topicPartitions = check resolveTopicPartitions(meta);
     string? dlqTopic = check dlq:resolveDeadLetterTopic(config.consumer.deadLetterTopic, meta);
     if dlqTopic is string {

--- a/components/messagestore/modules/kafka/consumer.bal
+++ b/components/messagestore/modules/kafka/consumer.bal
@@ -161,11 +161,12 @@ isolated client class Consumer {
 # + groupId - The default Kafka consumer group to which this consumer should belong to
 # + topic - The Kafka topic to which the consumer should received events for
 # + config - The Kafka connection configurations
+# + systemConsumer - Flag to indicate whether this is a system consumer
 # + meta - The meta data required to resolve the Kafka consumer group and topic partitions, 
 # if the user provided a `meta` information it would have a higher priority than the `groupId` provided. 
 # As of now only consumer-group and topic-partitions can be provided as `meta`
 # + return - A `store:Consumer` for Kafka message store, or else return an `error` if the operation fails
-public isolated function createConsumer(string groupId, string topic, Config config, record {} meta = {}) returns api:Consumer|error {
+public isolated function createConsumer(string groupId, string topic, Config config, boolean systemConsumer, record {} meta = {}) returns api:Consumer|error {
 
     string consumerGroup = check resolveConsumerGroup(groupId, meta);
     int[]? topicPartitions = check resolveTopicPartitions(meta);
@@ -183,7 +184,7 @@ isolated function resolveConsumerGroup(string defaultGroupId, record {} meta) re
     if meta.hasKey(CONSUMER_GROUP) {
         return value:ensureType(meta[CONSUMER_GROUP]);
     }
-    return defaultGroupId;
+    return string `consumer-${defaultGroupId}`;
 }
 
 isolated function resolveTopicPartitions(record {} meta) returns int[]|error? {

--- a/components/messagestore/modules/solace/admin.bal
+++ b/components/messagestore/modules/solace/admin.bal
@@ -72,7 +72,7 @@ public isolated client class Administrator {
     }
 
     isolated remote function createSubscription(string topic, string queueName, boolean systemSubscriber = false, record {} meta = {}) returns api:SubscriptionExists|error? {
-        string effectiveQueueName = systemSubscriber ? queueName: resolveQueueName(queueName, meta);
+        string effectiveQueueName = systemSubscriber ? queueName : resolveQueueName(self.queueConfig, queueName, meta);
         string effectiveDlqName = resolveDlqName(effectiveQueueName, meta);
         log:printWarn("Creating topic subscription for ", topic = topic, queue = effectiveQueueName, meta = meta);
         semp:MsgVpnQueue|error queue = self.retrieveQueue(effectiveQueueName);
@@ -91,7 +91,7 @@ public isolated client class Administrator {
     }
 
     isolated remote function deleteSubscription(string topic, string queueName, boolean systemSubscriber = false, record {} meta = {}) returns api:SubscriptionNotFound|error? {
-        string effectiveQueueName = systemSubscriber ? queueName: resolveQueueName(queueName, meta);
+        string effectiveQueueName = systemSubscriber ? queueName : resolveQueueName(self.queueConfig, queueName, meta);
         string effectiveDlqName = resolveDlqName(effectiveQueueName, meta);
         semp:MsgVpnQueueSubscription[]? subscriptions = check self.retrieveTopicSubscriptions(effectiveQueueName);
         if subscriptions is () {
@@ -286,9 +286,16 @@ public isolated client class Administrator {
     }
 }
 
-isolated function resolveQueueName(string queueName, record {} meta) returns string {
+isolated function resolveQueueName(SolaceQueueConfig? queueConfig, string queueId, record {} meta) returns string {
     anydata val = meta[META_QUEUE_NAME];
-    return val is string ? val : queueName;
+    if val is string {
+        return val;
+    }
+    string? queueNamePrefix = queueConfig?.queueNamePrefix;
+    if queueNamePrefix is string {
+        return string `${queueNamePrefix}${queueId}`;
+    }
+    return string `consumer-${queueId}`;
 }
 
 isolated function resolveDlqName(string queueName, record {} meta) returns string {

--- a/components/messagestore/modules/solace/admin.bal
+++ b/components/messagestore/modules/solace/admin.bal
@@ -74,7 +74,7 @@ public isolated client class Administrator {
     isolated remote function createSubscription(string topic, string queueName, boolean systemSubscriber = false, record {} meta = {}) returns api:SubscriptionExists|error? {
         string effectiveQueueName = systemSubscriber ? queueName : resolveQueueName(self.queueConfig, queueName, meta);
         string effectiveDlqName = resolveDlqName(effectiveQueueName, meta);
-        log:printWarn("Creating topic subscription for ", topic = topic, queue = effectiveQueueName, meta = meta);
+        log:printWarn("Creating topic subscription for ", topic = topic, queue = effectiveQueueName, dlq = effectiveDlqName);
         semp:MsgVpnQueue|error queue = self.retrieveQueue(effectiveQueueName);
         if queue is SolaceQueueNotFound {
             semp:MsgVpnQueue|error dlq = self.retrieveQueue(effectiveDlqName);

--- a/components/messagestore/modules/solace/admin.bal
+++ b/components/messagestore/modules/solace/admin.bal
@@ -358,14 +358,26 @@ isolated function buildQueuePayload(string queueName, string? dlqName, SolaceQue
     if dcVal is boolean {
         payload.deliveryCountEnabled = dcVal;
     } else if dcVal is string {
-        payload.deliveryCountEnabled = dcVal == "true";
+        if dcVal == "true" || dcVal == "false" {
+            payload.deliveryCountEnabled = dcVal == "true";
+        } else {
+            return error(string `invalid meta value for '${META_DELIVERY_COUNT_ENABLED}': "${dcVal}", expected boolean or "true"/"false"`);
+        }
+    } else if dcVal !is () {
+        return error(string `invalid meta value for '${META_DELIVERY_COUNT_ENABLED}': expected boolean or string`);
     }
 
     anydata ttlVal = meta[META_RESPECT_TTL];
     if ttlVal is boolean {
         payload.respectTtlEnabled = ttlVal;
     } else if ttlVal is string {
-        payload.respectTtlEnabled = ttlVal == "true";
+        if ttlVal == "true" || ttlVal == "false" {
+            payload.respectTtlEnabled = ttlVal == "true";
+        } else {
+            return error(string `invalid meta value for '${META_RESPECT_TTL}': "${ttlVal}", expected boolean or "true"/"false"`);
+        }
+    } else if ttlVal !is () {
+        return error(string `invalid meta value for '${META_RESPECT_TTL}': expected boolean or string`);
     }
 
     anydata maxTtlVal = meta[META_MAX_TTL];
@@ -382,7 +394,13 @@ isolated function buildQueuePayload(string queueName, string? dlqName, SolaceQue
     if redeliveryVal is boolean {
         payload.redeliveryEnabled = redeliveryVal;
     } else if redeliveryVal is string {
-        payload.redeliveryEnabled = redeliveryVal == "true";
+        if redeliveryVal == "true" || redeliveryVal == "false" {
+            payload.redeliveryEnabled = redeliveryVal == "true";
+        } else {
+            return error(string `invalid meta value for '${META_REDELIVERY_ENABLED}': "${redeliveryVal}", expected boolean or "true"/"false"`);
+        }
+    } else if redeliveryVal !is () {
+        return error(string `invalid meta value for '${META_REDELIVERY_ENABLED}': expected boolean or string`);
     }
 
     anydata maxCountVal = meta[META_REDELIVERY_MAX_COUNT];

--- a/components/messagestore/modules/solace/admin.bal
+++ b/components/messagestore/modules/solace/admin.bal
@@ -63,16 +63,16 @@ public isolated client class Administrator {
         self.queueConfig = config.queue.cloneReadOnly();
     }
 
-    isolated remote function createTopic(string topic, record {} meta = {}) returns api:TopicExists|error? {
+    isolated remote function createTopic(string topic, boolean systemTopic = false, record {} meta = {}) returns api:TopicExists|error? {
         return;
     }
 
-    isolated remote function deleteTopic(string topic, record {} meta = {}) returns api:TopicNotFound|error? {
+    isolated remote function deleteTopic(string topic, boolean systemTopic = false, record {} meta = {}) returns api:TopicNotFound|error? {
         return;
     }
 
-    isolated remote function createSubscription(string topic, string queueName, record {} meta = {}) returns api:SubscriptionExists|error? {
-        string effectiveQueueName = resolveQueueName(queueName, meta);
+    isolated remote function createSubscription(string topic, string queueName, boolean systemSubscriber = false, record {} meta = {}) returns api:SubscriptionExists|error? {
+        string effectiveQueueName = systemSubscriber ? queueName: resolveQueueName(queueName, meta);
         string effectiveDlqName = resolveDlqName(effectiveQueueName, meta);
         log:printWarn("Creating topic subscription for ", topic = topic, queue = effectiveQueueName, meta = meta);
         semp:MsgVpnQueue|error queue = self.retrieveQueue(effectiveQueueName);
@@ -90,8 +90,8 @@ public isolated client class Administrator {
         _ = check self.addTopicSubscription(effectiveQueueName, topic);
     }
 
-    isolated remote function deleteSubscription(string topic, string queueName, record {} meta = {}) returns api:SubscriptionNotFound|error? {
-        string effectiveQueueName = resolveQueueName(queueName, meta);
+    isolated remote function deleteSubscription(string topic, string queueName, boolean systemSubscriber = false, record {} meta = {}) returns api:SubscriptionNotFound|error? {
+        string effectiveQueueName = systemSubscriber ? queueName: resolveQueueName(queueName, meta);
         string effectiveDlqName = resolveDlqName(effectiveQueueName, meta);
         semp:MsgVpnQueueSubscription[]? subscriptions = check self.retrieveTopicSubscriptions(effectiveQueueName);
         if subscriptions is () {

--- a/components/messagestore/modules/solace/admin.bal
+++ b/components/messagestore/modules/solace/admin.bal
@@ -29,11 +29,25 @@ type SolaceQueueExists distinct error;
 
 type SolaceEntityExists distinct error;
 
+type SolaceQueuePermission "no-access"|"read-only"|"consume"|"modify-topic"|"delete";
+
+const string META_QUEUE_NAME = "solace.queue_name";
+const string META_DLQ_NAME = "solace.dlq_name";
+const string META_MAX_MSG_SPOOL = "solace.max_msg_spool";
+const string META_NON_OWNER_PERMISSION = "solace.non_owner_permission";
+const string META_DELIVERY_COUNT_ENABLED = "solace.delivery_count_enabled";
+const string META_RESPECT_TTL = "solace.respect_ttl";
+const string META_MAX_TTL = "solace.max_ttl";
+const string META_REDELIVERY_ENABLED = "solace.redelivery_enabled";
+const string META_REDELIVERY_TRY_FOREVER = "solace.redelivery_try_forever";
+const string META_REDELIVERY_MAX_COUNT = "solace.redelivery_max_count";
+
 public isolated client class Administrator {
     *api:Administrator;
 
     private final semp:Client administrator;
     private final string messageVpn;
+    private final readonly & SolaceQueueConfig? queueConfig;
 
     public isolated function init(Config config) returns error? {
         self.administrator = check new (
@@ -46,6 +60,7 @@ public isolated client class Administrator {
             }
         );
         self.messageVpn = config.messageVpn;
+        self.queueConfig = config.queue.cloneReadOnly();
     }
 
     isolated remote function createTopic(string topic, record {} meta = {}) returns api:TopicExists|error? {
@@ -57,25 +72,28 @@ public isolated client class Administrator {
     }
 
     isolated remote function createSubscription(string topic, string queueName, record {} meta = {}) returns api:SubscriptionExists|error? {
-        log:printWarn("Creating topic subscription for ", topic = topic, queue = queueName, meta = meta);
-        semp:MsgVpnQueue|error queue = self.retrieveQueue(queueName);
+        string effectiveQueueName = resolveQueueName(queueName, meta);
+        string effectiveDlqName = resolveDlqName(effectiveQueueName, meta);
+        log:printWarn("Creating topic subscription for ", topic = topic, queue = effectiveQueueName, meta = meta);
+        semp:MsgVpnQueue|error queue = self.retrieveQueue(effectiveQueueName);
         if queue is SolaceQueueNotFound {
-            string dlqName = string `dlq-${queueName}`;
-            semp:MsgVpnQueue|error dlq = self.retrieveQueue(dlqName);
+            semp:MsgVpnQueue|error dlq = self.retrieveQueue(effectiveDlqName);
             if dlq is SolaceQueueNotFound {
-                _ = check self.createQueue(dlqName);
+                _ = check self.createQueue(effectiveDlqName, (), self.queueConfig, meta);
             } else if dlq is error {
                 return dlq;
             }
-            _ = check self.createQueue(queueName, dlqName);
+            _ = check self.createQueue(effectiveQueueName, effectiveDlqName, self.queueConfig, meta);
         } else if queue is error {
             return queue;
         }
-        _ = check self.addTopicSubscription(queueName, topic);
+        _ = check self.addTopicSubscription(effectiveQueueName, topic);
     }
 
     isolated remote function deleteSubscription(string topic, string queueName, record {} meta = {}) returns api:SubscriptionNotFound|error? {
-        semp:MsgVpnQueueSubscription[]? subscriptions = check self.retrieveTopicSubscriptions(queueName);
+        string effectiveQueueName = resolveQueueName(queueName, meta);
+        string effectiveDlqName = resolveDlqName(effectiveQueueName, meta);
+        semp:MsgVpnQueueSubscription[]? subscriptions = check self.retrieveTopicSubscriptions(effectiveQueueName);
         if subscriptions is () {
             return;
         }
@@ -86,12 +104,11 @@ public isolated client class Administrator {
             return;
         }
 
-        _ = check self.removeTopicSubscription(queueName, topic);
+        _ = check self.removeTopicSubscription(effectiveQueueName, topic);
 
         if subscriptions.length() === 1 {
-            string dlqName = string `dlq-${queueName}`;
-            check self.deleteQueue(queueName);
-            check self.deleteQueue(dlqName);
+            check self.deleteQueue(effectiveQueueName);
+            check self.deleteQueue(effectiveDlqName);
         }
     }
 
@@ -123,16 +140,10 @@ public isolated client class Administrator {
         return response;
     }
 
-    isolated function createQueue(string queueName, string? dlq = ()) returns semp:MsgVpnQueue|error {
+    isolated function createQueue(string queueName, string? dlqName = (), SolaceQueueConfig? queueConfig = (), record {} meta = {}) returns semp:MsgVpnQueue|error {
         string vpn = self.messageVpn;
-        semp:MsgVpnQueueResponse|error response = self.administrator->createMsgVpnQueue(msgVpnName = vpn, payload = {
-            queueName,
-            deadMsgQueue: dlq,
-            accessType: "non-exclusive",
-            permission: "delete",
-            ingressEnabled: true,
-            egressEnabled: true
-        });
+        semp:MsgVpnQueue queuePayload = check buildQueuePayload(queueName, dlqName, queueConfig, meta);
+        semp:MsgVpnQueueResponse|error response = self.administrator->createMsgVpnQueue(msgVpnName = vpn, payload = queuePayload);
         if response is semp:MsgVpnQueueResponse {
             if response.data is semp:MsgVpnQueue {
                 return <semp:MsgVpnQueue>response.data;
@@ -273,4 +284,114 @@ public isolated client class Administrator {
     isolated remote function close() returns error? {
         return;
     }
+}
+
+isolated function resolveQueueName(string queueName, record {} meta) returns string {
+    anydata val = meta[META_QUEUE_NAME];
+    return val is string ? val : queueName;
+}
+
+isolated function resolveDlqName(string queueName, record {} meta) returns string {
+    anydata val = meta[META_DLQ_NAME];
+    return val is string ? val : string `dlq-${queueName}`;
+}
+
+isolated function buildQueuePayload(string queueName, string? dlqName, SolaceQueueConfig? queueConfig, record {} meta) returns semp:MsgVpnQueue|error {
+    semp:MsgVpnQueue payload = {
+        queueName,
+        accessType: "non-exclusive",
+        ingressEnabled: true,
+        egressEnabled: true
+    };
+
+    if dlqName is string {
+        payload.deadMsgQueue = dlqName;
+    }
+
+    if queueConfig is SolaceQueueConfig {
+        payload.owner = queueConfig.queueOwner;
+        payload.maxMsgSpoolUsage = queueConfig.messageQueueQuota;
+        payload.deliveryCountEnabled = queueConfig.deliveryCountEnabled;
+        payload.respectTtlEnabled = queueConfig.respectTtl;
+        payload.maxTtl = queueConfig.maxTtl;
+        payload.permission = check queueConfig.nonOwnerPermission.cloneWithType(SolaceQueuePermission);
+
+        var redeliver = queueConfig.redeliver;
+        if redeliver is record {|int maxCount;|} {
+            payload.redeliveryEnabled = true;
+            payload.maxRedeliveryCount = redeliver.maxCount;
+        } else if redeliver is record {|boolean tryForever;|} && redeliver.tryForever {
+            payload.redeliveryEnabled = true;
+            payload.maxRedeliveryCount = 0;
+        }
+    }
+
+    anydata spoolVal = meta[META_MAX_MSG_SPOOL];
+    if spoolVal is int {
+        payload.maxMsgSpoolUsage = spoolVal;
+    } else if spoolVal is string {
+        int|error parsed = int:fromString(spoolVal);
+        if parsed is int {
+            payload.maxMsgSpoolUsage = parsed;
+        }
+    }
+
+    anydata permVal = meta[META_NON_OWNER_PERMISSION];
+    if permVal is string {
+        SolaceQueuePermission|error perm = permVal.cloneWithType(SolaceQueuePermission);
+        if perm is SolaceQueuePermission {
+            payload.permission = perm;
+        }
+    }
+
+    anydata dcVal = meta[META_DELIVERY_COUNT_ENABLED];
+    if dcVal is boolean {
+        payload.deliveryCountEnabled = dcVal;
+    } else if dcVal is string {
+        payload.deliveryCountEnabled = dcVal == "true";
+    }
+
+    anydata ttlVal = meta[META_RESPECT_TTL];
+    if ttlVal is boolean {
+        payload.respectTtlEnabled = ttlVal;
+    } else if ttlVal is string {
+        payload.respectTtlEnabled = ttlVal == "true";
+    }
+
+    anydata maxTtlVal = meta[META_MAX_TTL];
+    if maxTtlVal is int {
+        payload.maxTtl = maxTtlVal;
+    } else if maxTtlVal is string {
+        int|error parsed = int:fromString(maxTtlVal);
+        if parsed is int {
+            payload.maxTtl = parsed;
+        }
+    }
+
+    anydata redeliveryVal = meta[META_REDELIVERY_ENABLED];
+    if redeliveryVal is boolean {
+        payload.redeliveryEnabled = redeliveryVal;
+    } else if redeliveryVal is string {
+        payload.redeliveryEnabled = redeliveryVal == "true";
+    }
+
+    anydata maxCountVal = meta[META_REDELIVERY_MAX_COUNT];
+    if maxCountVal is int {
+        payload.redeliveryEnabled = true;
+        payload.maxRedeliveryCount = maxCountVal;
+    } else if maxCountVal is string {
+        int|error parsed = int:fromString(maxCountVal);
+        if parsed is int {
+            payload.redeliveryEnabled = true;
+            payload.maxRedeliveryCount = parsed;
+        }
+    }
+
+    anydata tryForeverVal = meta[META_REDELIVERY_TRY_FOREVER];
+    if (tryForeverVal is boolean && tryForeverVal) || tryForeverVal == "true" {
+        payload.redeliveryEnabled = true;
+        payload.maxRedeliveryCount = 0;
+    }
+
+    return payload;
 }

--- a/components/messagestore/modules/solace/admin.bal
+++ b/components/messagestore/modules/solace/admin.bal
@@ -293,7 +293,10 @@ isolated function resolveQueueName(string queueName, record {} meta) returns str
 
 isolated function resolveDlqName(string queueName, record {} meta) returns string {
     anydata val = meta[META_DLQ_NAME];
-    return val is string ? val : string `dlq-${queueName}`;
+    if val is string {
+        return val;
+    }
+    return string `dlq-${queueName}`;
 }
 
 isolated function buildQueuePayload(string queueName, string? dlqName, SolaceQueueConfig? queueConfig, record {} meta) returns semp:MsgVpnQueue|error {

--- a/components/messagestore/modules/solace/consumer.bal
+++ b/components/messagestore/modules/solace/consumer.bal
@@ -87,8 +87,10 @@ isolated client class Consumer {
 #
 # + config - The Solace connection configurations
 # + queueName - The queue from which the consumer is receiving messages
-# + meta - The meta data required to resolve the consumer configurations
+# + meta - The meta data required to resolve the consumer configurations,
+# if `solace.queue_name` is present it takes priority over the `queueName` parameter
 # + return - A `store:Consumer` for Kafka message store, or else return an `error` if the operation fails
 public isolated function createConsumer(string queueName, Config config, record {} meta = {}) returns api:Consumer|error {
-    return new Consumer(config, queueName);
+    string effectiveQueueName = resolveQueueName(queueName, meta);
+    return new Consumer(config, effectiveQueueName);
 }

--- a/components/messagestore/modules/solace/consumer.bal
+++ b/components/messagestore/modules/solace/consumer.bal
@@ -94,6 +94,6 @@ isolated client class Consumer {
 # if `solace.queue_name` is present it takes priority over the `queueName` parameter
 # + return - A `store:Consumer` for Kafka message store, or else return an `error` if the operation fails
 public isolated function createConsumer(string queueName, Config config, boolean systemConsumer = false, record {} meta = {}) returns api:Consumer|error {
-    string effectiveQueueName = systemConsumer ? queueName: resolveQueueName(config.queue, queueName, meta);
+    string effectiveQueueName = systemConsumer ? queueName : resolveQueueName(config.queue, queueName, meta);
     return new Consumer(config, effectiveQueueName);
 }

--- a/components/messagestore/modules/solace/consumer.bal
+++ b/components/messagestore/modules/solace/consumer.bal
@@ -83,14 +83,17 @@ isolated client class Consumer {
     }
 }
 
+// todo: fix system queue consumer creation
+
 # Initialize a consumer for Solace message store.
 #
 # + config - The Solace connection configurations
 # + queueName - The queue from which the consumer is receiving messages
+# + systemConsumer - Flag to indicate whether this is a system consumer
 # + meta - The meta data required to resolve the consumer configurations,
 # if `solace.queue_name` is present it takes priority over the `queueName` parameter
 # + return - A `store:Consumer` for Kafka message store, or else return an `error` if the operation fails
-public isolated function createConsumer(string queueName, Config config, record {} meta = {}) returns api:Consumer|error {
-    string effectiveQueueName = resolveQueueName(queueName, meta);
+public isolated function createConsumer(string queueName, Config config, boolean systemConsumer = false, record {} meta = {}) returns api:Consumer|error {
+    string effectiveQueueName = systemConsumer ? queueName: resolveQueueName(config.queue, queueName, meta);
     return new Consumer(config, effectiveQueueName);
 }

--- a/components/messagestore/modules/solace/type.bal
+++ b/components/messagestore/modules/solace/type.bal
@@ -25,7 +25,7 @@ public type Config record {|
     SolaceConsumerConfig consumer;
     SolaceAdminConfig admin;
     # Solace queue configurations
-    SolaceQueueConfig queue?;
+    SolaceQueueConfig queue;
 |};
 
 # Defines the configurations for establishing a connection to a Solace event broker.
@@ -62,8 +62,8 @@ public type SolaceConsumerConfig record {|
 
 # Configuration for creating and managing a Solace queue.
 public type SolaceQueueConfig record {|
-    # Prefix used when generating the Solace queue name.
-    string queueNamePrefix;
+    # Prefix used when generating the Solace queue name for consumer queues.
+    string queueNamePrefix?;
     # Maximum message spool quota for the queue in MB.
     int messageQueueQuota = 5000;
     # Client username that owns the queue.

--- a/components/messagestore/modules/solace/type.bal
+++ b/components/messagestore/modules/solace/type.bal
@@ -24,6 +24,8 @@ public type Config record {|
     # Solace consumer-specific configurations
     SolaceConsumerConfig consumer;
     SolaceAdminConfig admin;
+    # Solace queue configurations
+    SolaceQueueConfig queue?;
 |};
 
 # Defines the configurations for establishing a connection to a Solace event broker.
@@ -56,6 +58,32 @@ public type SolaceConnectionConfig record {|
 public type SolaceConsumerConfig record {|
     # The timeout to wait for one receive call to the Solace message store
     decimal receiveTimeout = 10;
+|};
+
+# Configuration for creating and managing a Solace queue.
+public type SolaceQueueConfig record {|
+    # Prefix used when generating the Solace queue name.
+    string queueNamePrefix;
+    # Maximum message spool quota for the queue in MB.
+    int messageQueueQuota = 5000;
+    # Client username that owns the queue.
+    string queueOwner;
+    # Permission level granted to non-owner clients.
+    string nonOwnerPermission = "no-access";
+    # Enables tracking of message delivery attempts.
+    boolean deliveryCountEnabled = true;
+    # Indicates whether message TTL should be respected.
+    boolean respectTtl = false;
+    # Maximum allowed TTL for messages in seconds. A value of `0` indicates no explicit maximum.
+    int maxTtl = 0;
+    # Redelivery configuration.
+    record {|
+        # Maximum number of redelivery attempts.
+        int maxCount;
+    |}|record {|
+        # Indicates whether messages should be retried indefinitely.
+        boolean tryForever = true;
+    |} redeliver?;
 |};
 
 # Defines configurations for the Solace administrator.

--- a/components/websubhub-consolidator/Config.toml
+++ b/components/websubhub-consolidator/Config.toml
@@ -37,5 +37,15 @@ offsetReset = "earliest"
 # auth.username = "admin"
 # auth.password = "admin"
 
+# [websubhub.consolidator.config.store.solace.queue]
+# queueNamePrefix = "consumer"
+# messageQueueQuota = 5000
+# queueOwner = "default"
+# nonOwnerPermission = "no-access"
+# deliveryCountEnabled = true
+# respectTtl = false
+# maxTtl = 0
+# redeliver.maxCount = 10
+
 [ballerina.log]
 level = "INFO"

--- a/components/websubhub-consolidator/Config.toml
+++ b/components/websubhub-consolidator/Config.toml
@@ -38,7 +38,6 @@ offsetReset = "earliest"
 # auth.password = "admin"
 
 # [websubhub.consolidator.config.store.solace.queue]
-# queueNamePrefix = "consumer"
 # messageQueueQuota = 5000
 # queueOwner = "default"
 # nonOwnerPermission = "no-access"

--- a/components/websubhub-consolidator/Dependencies.toml
+++ b/components/websubhub-consolidator/Dependencies.toml
@@ -413,9 +413,10 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "solace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerinai", name = "observe"}
 ]
 
 [[package]]

--- a/components/websubhub-consolidator/modules/admin/admin.bal
+++ b/components/websubhub-consolidator/modules/admin/admin.bal
@@ -32,7 +32,7 @@ isolated function init() returns error? {
 
 isolated function createStateSnapshotSubscription() returns error? {
     var {topic, consumerId} = config:state.snapshot;
-    error? result = administrator->createSubscription(topic, consumerId);
+    error? result = administrator->createSubscription(topic, consumerId, true);
     if result is storeapi:SubscriptionExists {
         log:printWarn(string `Subscription for Topic [${topic}] and Subscriber [${consumerId}] exists`);
         return;
@@ -42,7 +42,7 @@ isolated function createStateSnapshotSubscription() returns error? {
 
 isolated function createStateEventsSubscription() returns error? {
     var {topic, consumerId} = config:state.events;
-    error? result = administrator->createSubscription(topic, consumerId);
+    error? result = administrator->createSubscription(topic, consumerId, true);
     if result is storeapi:SubscriptionExists {
         log:printWarn(string `Subscription for Topic [${topic}] and Subscriber [${consumerId}] exists`);
         return;

--- a/components/websubhub-consolidator/modules/connections/connections.bal
+++ b/components/websubhub-consolidator/modules/connections/connections.bal
@@ -34,14 +34,14 @@ function initStatePersistProducer() returns storeapi:Producer|error {
 public final storeapi:Consumer websubEventsConsumer = check initWebSubEventsConsumer();
 
 function initWebSubEventsConsumer() returns storeapi:Consumer|error {
-    return store:createConsumer(config:state.events.topic, config:state.events.consumerId, config:store);
+    return store:createConsumer(config:state.events.topic, config:state.events.consumerId, config:store, true);
 }
 
 # Initializes the WebSub event snapshot consumer.
 #
 # + return - A `store:Consumer` for the message store, or else return an `error` if the operation fails
 public isolated function initWebSubEventSnapshotConsumer() returns storeapi:Consumer|error {
-    return store:createConsumer(config:state.snapshot.topic, config:state.snapshot.consumerId, config:store);
+    return store:createConsumer(config:state.snapshot.topic, config:state.snapshot.consumerId, config:store, true);
 }
 
 # Retrieves a message producer per topic.

--- a/components/websubhub/Config.toml
+++ b/components/websubhub/Config.toml
@@ -40,6 +40,16 @@ gracefulClosePeriod = 5.0
 # auth.username = "admin"
 # auth.password = "admin"
 
+# [websubhub.config.store.solace.queue]
+# queueNamePrefix = "consumer"
+# messageQueueQuota = 5000
+# queueOwner = "default"
+# nonOwnerPermission = "no-access"
+# deliveryCountEnabled = true
+# respectTtl = false
+# maxTtl = 0
+# redeliver.maxCount = 10
+
 [websubhub.config.delivery]
 timeout = 60.0
 

--- a/components/websubhub/Config.toml
+++ b/components/websubhub/Config.toml
@@ -41,7 +41,7 @@ gracefulClosePeriod = 5.0
 # auth.password = "admin"
 
 # [websubhub.config.store.solace.queue]
-# queueNamePrefix = "consumer"
+# queueNamePrefix = "consumer-"
 # messageQueueQuota = 5000
 # queueOwner = "default"
 # nonOwnerPermission = "no-access"

--- a/components/websubhub/Dependencies.toml
+++ b/components/websubhub/Dependencies.toml
@@ -438,9 +438,10 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "solace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerinai", name = "observe"}
 ]
 
 [[package]]

--- a/components/websubhub/hub_service.bal
+++ b/components/websubhub/hub_service.bal
@@ -242,8 +242,7 @@ websubhub:Service hubService = @websubhub:ServiceConfig {
         }
 
         do {
-            message[common:SUBSCRIPTION_TIMESTAMP] = subscription[common:SUBSCRIPTION_TIMESTAMP];
-            check admin:deleteSubscription(message);
+            check admin:deleteSubscription(subscription);
             check persist:removeSubscription(message);
         } on fail error unsubscriptionErr {
             string errorMessage = string

--- a/components/websubhub/modules/admin/admin.bal
+++ b/components/websubhub/modules/admin/admin.bal
@@ -73,16 +73,16 @@ public isolated function createSubscription(websubhub:VerifiedSubscription subsc
     return result;
 }
 
-public isolated function deleteSubscription(websubhub:VerifiedUnsubscription unsubscription)
+public isolated function deleteSubscription(websubhub:VerifiedSubscription subscription)
     returns websubhub:InternalUnsubscriptionError|error? {
 
-    string topic = unsubscription.hubTopic;
-    string timestamp = check value:ensureType(unsubscription[common:SUBSCRIPTION_TIMESTAMP]);
-    string consumerName = constructConsumerId(topic, unsubscription.hubCallback, timestamp);
-    error? result = administrator->deleteSubscription(topic, consumerName, false, unsubscription);
+    string topic = subscription.hubTopic;
+    string timestamp = check value:ensureType(subscription[common:SUBSCRIPTION_TIMESTAMP]);
+    string consumerName = constructConsumerId(topic, subscription.hubCallback, timestamp);
+    error? result = administrator->deleteSubscription(topic, consumerName, false, subscription);
     if result is storeapi:SubscriptionNotFound {
         string errorMessage = string `
-            Subscription for topic ${topic} and callback ${unsubscription.hubCallback} with consumer-name ${consumerName} can not be found in the message store.`;
+            Subscription for topic ${topic} and callback ${subscription.hubCallback} with consumer-name ${consumerName} can not be found in the message store.`;
         return error websubhub:InternalUnsubscriptionError(errorMessage, statusCode = http:STATUS_NOT_FOUND);
     }
     return result;

--- a/components/websubhub/modules/admin/admin.bal
+++ b/components/websubhub/modules/admin/admin.bal
@@ -28,7 +28,7 @@ import wso2/messagestore.api as storeapi;
 final storeapi:Administrator administrator = check store:createAdministrator(config:store);
 
 public isolated function createWebSubEventsSubscription(string topic, string consumerId) returns error? {
-    error? result = administrator->createSubscription(topic, consumerId);
+    error? result = administrator->createSubscription(topic, consumerId, true);
     if result is storeapi:SubscriptionExists {
         log:printWarn(string `Subscription for Topic [${topic}] and Subscriber [${consumerId}] exists`);
         return;
@@ -39,7 +39,7 @@ public isolated function createWebSubEventsSubscription(string topic, string con
 public isolated function createTopic(websubhub:TopicRegistration topicRegistration)
     returns websubhub:TopicRegistrationError|error? {
 
-    error? result = administrator->createTopic(topicRegistration.topic, topicRegistration);
+    error? result = administrator->createTopic(topicRegistration.topic, false, topicRegistration);
     if result is storeapi:TopicExists {
         string errorMessage = string `Topic ${topicRegistration.topic} already exists in the message store, deregister the topic first.`;
         return error websubhub:TopicRegistrationError(errorMessage, statusCode = http:STATUS_CONFLICT);
@@ -50,7 +50,7 @@ public isolated function createTopic(websubhub:TopicRegistration topicRegistrati
 public isolated function deleteTopic(websubhub:TopicDeregistration topicDeregistration)
     returns websubhub:TopicDeregistrationError|error? {
 
-    error? result = administrator->deleteTopic(topicDeregistration.topic, topicDeregistration);
+    error? result = administrator->deleteTopic(topicDeregistration.topic, false, topicDeregistration);
     if result is storeapi:TopicNotFound {
         string errorMessage = string `Topic ${topicDeregistration.topic} could not be found in the message store.`;
         return error websubhub:TopicDeregistrationError(errorMessage, statusCode = http:STATUS_NOT_FOUND);
@@ -64,7 +64,7 @@ public isolated function createSubscription(websubhub:VerifiedSubscription subsc
     string topic = subscription.hubTopic;
     string timestamp = check value:ensureType(subscription[common:SUBSCRIPTION_TIMESTAMP]);
     string consumerName = constructConsumerName(topic, subscription.hubCallback, timestamp);
-    error? result = administrator->createSubscription(topic, consumerName, subscription);
+    error? result = administrator->createSubscription(topic, consumerName, false, subscription);
     if result is storeapi:SubscriptionExists {
         string errorMessage = string `
             Subscription for topic ${topic} and callback ${subscription.hubCallback} with consumer-name ${consumerName} already exists in the message store.`;
@@ -79,7 +79,7 @@ public isolated function deleteSubscription(websubhub:VerifiedUnsubscription uns
     string topic = unsubscription.hubTopic;
     string timestamp = check value:ensureType(unsubscription[common:SUBSCRIPTION_TIMESTAMP]);
     string consumerName = constructConsumerName(topic, unsubscription.hubCallback, timestamp);
-    error? result = administrator->deleteSubscription(topic, consumerName, unsubscription);
+    error? result = administrator->deleteSubscription(topic, consumerName, false, unsubscription);
     if result is storeapi:SubscriptionNotFound {
         string errorMessage = string `
             Subscription for topic ${topic} and callback ${unsubscription.hubCallback} with consumer-name ${consumerName} can not be found in the message store.`;

--- a/components/websubhub/modules/admin/admin.bal
+++ b/components/websubhub/modules/admin/admin.bal
@@ -63,7 +63,7 @@ public isolated function createSubscription(websubhub:VerifiedSubscription subsc
 
     string topic = subscription.hubTopic;
     string timestamp = check value:ensureType(subscription[common:SUBSCRIPTION_TIMESTAMP]);
-    string consumerName = constructConsumerName(topic, subscription.hubCallback, timestamp);
+    string consumerName = constructConsumerId(topic, subscription.hubCallback, timestamp);
     error? result = administrator->createSubscription(topic, consumerName, false, subscription);
     if result is storeapi:SubscriptionExists {
         string errorMessage = string `
@@ -78,7 +78,7 @@ public isolated function deleteSubscription(websubhub:VerifiedUnsubscription uns
 
     string topic = unsubscription.hubTopic;
     string timestamp = check value:ensureType(unsubscription[common:SUBSCRIPTION_TIMESTAMP]);
-    string consumerName = constructConsumerName(topic, unsubscription.hubCallback, timestamp);
+    string consumerName = constructConsumerId(topic, unsubscription.hubCallback, timestamp);
     error? result = administrator->deleteSubscription(topic, consumerName, false, unsubscription);
     if result is storeapi:SubscriptionNotFound {
         string errorMessage = string `
@@ -88,11 +88,11 @@ public isolated function deleteSubscription(websubhub:VerifiedUnsubscription uns
     return result;
 }
 
-isolated function constructConsumerName(string topic, string hubCallback, string timestamp) returns string {
+isolated function constructConsumerId(string topic, string hubCallback, string timestamp) returns string {
     string subscriberId = string `${topic}___${hubCallback}___${timestamp}`;
     int constructedId = 0;
     foreach var [idx, val] in subscriberId.toCodePointInts().enumerate() {
         constructedId += (idx + 1) * val;
     }
-    return string `consumer-${constructedId}`;
+    return string `${constructedId}`;
 }

--- a/components/websubhub/modules/connections/connections.bal
+++ b/components/websubhub/modules/connections/connections.bal
@@ -38,7 +38,7 @@ public final storeapi:Consumer websubEventsConsumer = check initWebSubEventsCons
 function initWebSubEventsConsumer() returns storeapi:Consumer|error {
     string websubEventsConsumerId = string `${config:state.events.consumerIdPrefix}-${config:serverId}`;
     check admin:createWebSubEventsSubscription(config:state.events.topic, websubEventsConsumerId);
-    return store:createConsumer(config:state.events.topic, websubEventsConsumerId, config:store);
+    return store:createConsumer(config:state.events.topic, websubEventsConsumerId, config:store, true);
 }
 
 # Initialize a `store:Consumer` for a WebSub subscriber.
@@ -48,7 +48,7 @@ function initWebSubEventsConsumer() returns storeapi:Consumer|error {
 public isolated function createConsumer(websubhub:VerifiedSubscription subscription) returns storeapi:Consumer|error {
     string topic = subscription.hubTopic;
     string defaultConsumerId = check constructDefaultConsumerId(subscription);
-    return store:createConsumer(topic, defaultConsumerId, config:store);
+    return store:createConsumer(topic, defaultConsumerId, config:store, false, subscription);
 }
 
 isolated function constructDefaultConsumerId(websubhub:VerifiedSubscription subscription) returns string|error {
@@ -58,7 +58,7 @@ isolated function constructDefaultConsumerId(websubhub:VerifiedSubscription subs
     foreach var [idx, val] in subscriberId.toCodePointInts().enumerate() {
         constructedId += (idx + 1) * val;
     }
-    return string `consumer-${constructedId}`;
+    return string `${constructedId}`;
 }
 
 # Retrieves a message producer per topic.

--- a/distribution/conf/websubhub-consolidator/Config.toml
+++ b/distribution/conf/websubhub-consolidator/Config.toml
@@ -37,5 +37,15 @@ offsetReset = "earliest"
 # auth.username = "admin"
 # auth.password = "admin"
 
+# [websubhub.consolidator.config.store.solace.queue]
+# queueNamePrefix = "consumer"
+# messageQueueQuota = 5000
+# queueOwner = "default"
+# nonOwnerPermission = "no-access"
+# deliveryCountEnabled = true
+# respectTtl = false
+# maxTtl = 0
+# redeliver.maxCount = 10
+
 [ballerina.log]
 level = "INFO"

--- a/distribution/conf/websubhub-consolidator/Config.toml
+++ b/distribution/conf/websubhub-consolidator/Config.toml
@@ -38,7 +38,6 @@ offsetReset = "earliest"
 # auth.password = "admin"
 
 # [websubhub.consolidator.config.store.solace.queue]
-# queueNamePrefix = "consumer"
 # messageQueueQuota = 5000
 # queueOwner = "default"
 # nonOwnerPermission = "no-access"

--- a/distribution/conf/websubhub/Config.toml
+++ b/distribution/conf/websubhub/Config.toml
@@ -40,6 +40,16 @@ gracefulClosePeriod = 5.0
 # auth.username = "admin"
 # auth.password = "admin"
 
+# [websubhub.config.store.solace.queue]
+# queueNamePrefix = "consumer"
+# messageQueueQuota = 5000
+# queueOwner = "default"
+# nonOwnerPermission = "no-access"
+# deliveryCountEnabled = true
+# respectTtl = false
+# maxTtl = 0
+# redeliver.maxCount = 10
+
 [websubhub.config.delivery]
 timeout = 60.0
 

--- a/distribution/conf/websubhub/Config.toml
+++ b/distribution/conf/websubhub/Config.toml
@@ -41,7 +41,7 @@ gracefulClosePeriod = 5.0
 # auth.password = "admin"
 
 # [websubhub.config.store.solace.queue]
-# queueNamePrefix = "consumer"
+# queueNamePrefix = "consumer-"
 # messageQueueQuota = 5000
 # queueOwner = "default"
 # nonOwnerPermission = "no-access"


### PR DESCRIPTION
## Summary

- Introduces `SolaceQueueConfig` record in `type.bal` to expose Solace queue creation properties: spool quota, owner, non-owner permissions, delivery-count tracking, TTL, and redelivery behaviour.
- Updates `SolaceConfig` (`Config`) to include an optional `queue?` field so the configuration is backward-compatible.
- Updates `Administrator.createSubscription` and `deleteSubscription` in `admin.bal` to resolve the effective queue/DLQ names from `meta` (`solace.queue_name`, `solace.dlq_name`) and to apply the full `SolaceQueueConfig` (with per-subscription overrides) when creating queues via the SEMP v2 API.
- Updates `createConsumer` in `consumer.bal` to honour `solace.queue_name` in `meta`, overriding the default queue name when creating a Solace consumer.

### Supported subscription-level overrides (via WebSub `meta`)

| Parameter | SEMP v2 field |
|---|---|
| `solace.queue_name` | `queueName` |
| `solace.dlq_name` | `deadMsgQueue` |
| `solace.max_msg_spool` | `maxMsgSpoolUsage` |
| `solace.non_owner_permission` | `permission` |
| `solace.delivery_count_enabled` | `deliveryCountEnabled` |
| `solace.respect_ttl` | `respectTtlEnabled` |
| `solace.max_ttl` | `maxTtl` |
| `solace.redelivery_enabled` | `redeliveryEnabled` |
| `solace.redelivery_try_forever` | `maxRedeliveryCount = 0` |
| `solace.redelivery_max_count` | `maxRedeliveryCount` |

Closes #60
