### PR TITLE
Prevent false-positive stale subscriptions on transient broker receive errors

### DIFF
--- a/components/messagestore/Ballerina.toml
+++ b/components/messagestore/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "wso2"
 name = "messagestore"
-version = "1.0.5"
+version = "1.0.6-SNAPSHOT"
 distribution = "2201.13.3"
 
 [build-options]

--- a/components/messagestore/Dependencies.toml
+++ b/components/messagestore/Dependencies.toml
@@ -375,7 +375,7 @@ modules = [
 [[package]]
 org = "wso2"
 name = "messagestore"
-version = "1.0.5"
+version = "1.0.6-SNAPSHOT"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/components/messagestore/modules/api/api.bal
+++ b/components/messagestore/modules/api/api.bal
@@ -111,6 +111,12 @@ public type SubscriptionExists distinct error;
 # Error indicating that the specified subscription does not exist.
 public type SubscriptionNotFound distinct error;
 
+# Error indicating that receiving a message from the broker failed due to a broker or
+# consumer-side infrastructure problem (e.g. queue deleted, transient connection drop).
+# Callers should treat this as a transient error and avoid escalating it to permanent
+# outcomes such as marking a subscription stale.
+public type MessageReceiveError distinct error;
+
 # Represents an administrative client used to manage topics and subscriptions in the underlying message store.
 public isolated client class Administrator {
 

--- a/components/messagestore/modules/api/api.bal
+++ b/components/messagestore/modules/api/api.bal
@@ -113,8 +113,6 @@ public type SubscriptionNotFound distinct error;
 
 # Error indicating that receiving a message from the broker failed due to a broker or
 # consumer-side infrastructure problem (e.g. queue deleted, transient connection drop).
-# Callers should treat this as a transient error and avoid escalating it to permanent
-# outcomes such as marking a subscription stale.
 public type MessageReceiveError distinct error;
 
 # Represents an administrative client used to manage topics and subscriptions in the underlying message store.

--- a/components/messagestore/modules/jms/consumer.bal
+++ b/components/messagestore/modules/jms/consumer.bal
@@ -45,7 +45,12 @@ isolated client class Consumer {
     }
 
     isolated remote function receive() returns api:Message|error? {
-        jms:Message? receivedMsg = check self.consumer->receive(self.readTimeout);
+        jms:Message? receivedMsg;
+        do {
+            receivedMsg = check self.consumer->receive(self.readTimeout);
+        } on fail error e {
+            return error api:MessageReceiveError(e.message(), cause = e);
+        }
         if receivedMsg !is jms:BytesMessage {
             return;
         }

--- a/components/messagestore/modules/kafka/consumer.bal
+++ b/components/messagestore/modules/kafka/consumer.bal
@@ -99,7 +99,11 @@ isolated client class Consumer {
     }
 
     isolated remote function receive() returns api:Message|error? {
-        check self.updateCurrentBatch();
+        do {
+            check self.updateCurrentBatch();
+        } on fail error e {
+            return error api:MessageReceiveError(e.message(), cause = e);
+        }
         if self.isCurrentBatchEmpty() {
             return;
         }

--- a/components/messagestore/modules/solace/consumer.bal
+++ b/components/messagestore/modules/solace/consumer.bal
@@ -45,7 +45,12 @@ isolated client class Consumer {
     }
 
     isolated remote function receive() returns api:Message|error? {
-        solace:Message? receivedMsg = check self.consumer->receive(self.config.receiveTimeout);
+        solace:Message? receivedMsg;
+        do {
+            receivedMsg = check self.consumer->receive(self.config.receiveTimeout);
+        } on fail error e {
+            return error api:MessageReceiveError(e.message(), cause = e);
+        }
         if receivedMsg is () {
             return;
         }

--- a/components/websubhub-consolidator/Ballerina.toml
+++ b/components/websubhub-consolidator/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "wso2"
 name = "websubhub.consolidator"
-version = "1.0.5"
+version = "1.0.6-SNAPSHOT"
 distribution = "2201.13.3"
 
 [build-options]

--- a/components/websubhub-consolidator/Dependencies.toml
+++ b/components/websubhub-consolidator/Dependencies.toml
@@ -418,7 +418,7 @@ modules = [
 [[package]]
 org = "wso2"
 name = "websubhub.consolidator"
-version = "1.0.5"
+version = "1.0.6-SNAPSHOT"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/components/websubhub/Ballerina.toml
+++ b/components/websubhub/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "wso2"
 name = "websubhub"
-version = "1.0.5"
+version = "1.0.6-SNAPSHOT"
 distribution = "2201.13.3"
 
 [build-options]

--- a/components/websubhub/Dependencies.toml
+++ b/components/websubhub/Dependencies.toml
@@ -427,7 +427,7 @@ modules = [
 [[package]]
 org = "wso2"
 name = "websubhub"
-version = "1.0.5"
+version = "1.0.6-SNAPSHOT"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jwt"},

--- a/components/websubhub/modules/delivery/delivery.bal
+++ b/components/websubhub/modules/delivery/delivery.bal
@@ -107,6 +107,16 @@ isolated function startDispatchTask(websubhub:VerifiedSubscription subscription)
             return;
         }
 
+        if e is storeapi:MessageReceiveError {
+            // Transient broker-side error during receive (e.g. queue deleted during unsubscription,
+            // connection drop). Exit the worker cleanly without marking the subscription stale.
+            error? result = consumerEp->close(storeapi:TEMPORARY);
+            if result is error {
+                common:logRecoverableError("Error occurred while gracefully closing message store consumer", result);
+            }
+            return;
+        }
+
         error? result = consumerEp->close(storeapi:TEMPORARY);
         if result is error {
             common:logRecoverableError("Error occurred while gracefully closing message store consumer", result);

--- a/components/websubhub/modules/delivery/delivery.bal
+++ b/components/websubhub/modules/delivery/delivery.bal
@@ -108,8 +108,6 @@ isolated function startDispatchTask(websubhub:VerifiedSubscription subscription)
         }
 
         if e is storeapi:MessageReceiveError {
-            // Transient broker-side error during receive (e.g. queue deleted during unsubscription,
-            // connection drop). Exit the worker cleanly without marking the subscription stale.
             error? result = consumerEp->close(storeapi:TEMPORARY);
             if result is error {
                 common:logRecoverableError("Error occurred while gracefully closing message store consumer", result);


### PR DESCRIPTION
## Summary

- Introduces `MessageReceiveError` as a typed error in the `messagestore` API layer to represent broker/consumer-side failures during `receive()`.
- All three backends (Solace, JMS, Kafka) now wrap errors from their `receive()` call into `MessageReceiveError` instead of propagating raw, untyped errors.
- Adds a matching guard in the delivery worker's `on fail` block so that `MessageReceiveError` exits the worker cleanly — without writing a `stale` flag to the consolidator.

## Problem

A race condition between queue deletion (triggered by unsubscription) and a running consumer's blocking `receive()` call could mark a healthy subscription permanently stale via the delivery worker's catch-all. Whether it happened was timing-dependent:

- If the unsubscription state removal processed **before** the `on fail` block ran → `isValidConsumer` guard caught it safely, no stale.
- If the `on fail` block ran **first** → all three typed-error guards missed, catch-all fired → subscription incorrectly marked stale, delivery stopped until manual re-subscribe.

Confirmed in customer logs (2026-06-08): `503: Unknown Queue` from Solace hit the catch-all 40 ms before the unsubscription state removal, producing a false-positive stale on the `write-file` subscription.

## What changes

| File | Change |
|------|--------|
| `messagestore/modules/api/api.bal` | New `MessageReceiveError distinct error` |
| `messagestore/modules/solace/consumer.bal` | `receive()` wraps all Solace errors as `MessageReceiveError` |
| `messagestore/modules/jms/consumer.bal` | Same for JMS |
| `messagestore/modules/kafka/consumer.bal` | Same for Kafka (`updateCurrentBatch()` errors) |
| `websubhub/modules/delivery/delivery.bal` | New guard: `MessageReceiveError` → `close(TEMPORARY)` + return, no stale |

The existing `isValidConsumer` guard is unchanged and still handles the lucky-timing case. The new guard makes the unlucky-timing case deterministically safe.

## Test plan

- [ ] Build `messagestore` and `websubhub` components and confirm no type errors
- [ ] Manual Solace test (per `docs/SOLACE_TRYOUT.md`): subscribe a topic, unsubscribe while delivery is running, confirm no `"Error occurred while persisting the stale subscription"` log and no `status:"stale"` in the consolidator snapshot
- [ ] Re-subscribe after the above and confirm the consumer starts normally