### PR TITLE
Update .trivyignore: drop stale Netty CVE, suppress jackson-databind CVE-2026-54515

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,1 +1,2 @@
-CVE-2026-42577
+# jackson-databind (via ballerinax/confluent.cregistry) CVE fixed only in 2.18.9/2.21.5/2.22.1, none of which FasterXML has published to Maven Central yet (remove once a fixed version is released and the dependency is bumped)
+CVE-2026-54515


### PR DESCRIPTION
## Summary
- **Remove `CVE-2026-42577`**: this Netty epoll-transport DoS CVE only affects `netty-transport-native-epoll` 4.2.x (confirmed via NVD and GitHub's advisory API — vulnerable range `>= 4.2.0.Final, < 4.2.13.Final`). This repo bundles `netty-transport-native-epoll-4.1.135.Final` via `xlibb/solace` 0.4.2, entirely outside that range. Verified locally with `trivy rootfs` against both `websubhub.jar` and `websubhub.consolidator.jar` — the CVE does not appear as a finding (suppressed or otherwise) once removed.
- **Add `CVE-2026-54515`**: after bumping `ballerinax/confluent.cregistry` to `0.4.5` (which brings `jackson-databind` to `2.18.8`), this is the one remaining CVE from the original Trivy failure. It's fixed only in `2.18.9`/`2.21.5`/`2.22.1`, none of which FasterXML has published to Maven Central yet (verified against `repo1.maven.org` and Maven Central's `maven-metadata.xml`). Suppressed until a fixed version is released — see the comment in the file for the removal condition.

## Test plan
- [x] Local `trivy rootfs --scanners vuln` against `components/websubhub/target/bin` and `components/websubhub-consolidator/target/bin` shows 0 unignored vulnerabilities, with only `CVE-2026-54515` appearing in the suppressed list
- [ ] CI Trivy scan passes