### PR TITLE
Fix trivy-scan job missing repo checkout (.trivyignore was never applied)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,12 +110,15 @@ jobs:
           - "components/websubhub/target/bin"
           - "components/websubhub-consolidator/target/bin"
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
       - name: Download build output
         uses: actions/download-artifact@v8
         with:
           name: build-output
           path: components
-      
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         env:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -57,12 +57,15 @@ jobs:
           - "components/websubhub/target/bin"
           - "components/websubhub-consolidator/target/bin"
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
       - name: Download build output
         uses: actions/download-artifact@v8
         with:
           name: build-output
           path: components
-      
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         env:


### PR DESCRIPTION
## Summary
- The `trivy-scan` job in both `release.yml` and `trivy-scan.yml` only ran `actions/download-artifact` to pull the built jars into `components/` — it never checked out the repository. `.trivyignore` lives at the repo root, so it was never present in this job's workspace, and `aquasecurity/trivy-action` (which looks for `.trivyignore` relative to cwd by default) never actually applied any suppression in either workflow.
- This is why the release run in #103's follow-up still failed on `CVE-2026-54515` even though the `.trivyignore` entry for it was already merged to `main` — the ignore file was correct, but this job never saw it.
- Fix: add an `actions/checkout@v6` step as the first step of the `trivy-scan` job in both files, matching the checkout pattern already used in every other job in these workflows.

## Test plan
- [ ] Trigger `trivy-scan.yml` via `workflow_dispatch` and confirm the job log shows a checkout step, and that `CVE-2026-54515` now appears under "Suppressed Vulnerabilities" in the Trivy output instead of failing the job
- [ ] Next release run's `trivy-scan` job passes