### PR TITLE
Reorder observability imports and upgrade to xlibb/solace 0.5.0 with tracing/metrics support

### DIFF
--- a/components/messagestore/Ballerina.toml
+++ b/components/messagestore/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "wso2"
 name = "messagestore"
-version = "1.0.6"
+version = "1.0.7-SNAPSHOT"
 distribution = "2201.13.3"
 
 [build-options]

--- a/components/messagestore/Dependencies.toml
+++ b/components/messagestore/Dependencies.toml
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "avro"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -61,7 +61,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.4"
+version = "2.16.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -375,7 +375,7 @@ modules = [
 [[package]]
 org = "wso2"
 name = "messagestore"
-version = "1.0.6"
+version = "1.0.7-SNAPSHOT"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},
@@ -400,7 +400,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "solace"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/components/websubhub-consolidator/Ballerina.toml
+++ b/components/websubhub-consolidator/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "wso2"
 name = "websubhub.consolidator"
-version = "1.0.6"
+version = "1.0.7-SNAPSHOT"
 distribution = "2201.13.3"
 
 [build-options]

--- a/components/websubhub-consolidator/Dependencies.toml
+++ b/components/websubhub-consolidator/Dependencies.toml
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "avro"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -58,7 +58,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.4"
+version = "2.16.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -367,7 +367,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "jaeger"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -418,7 +418,7 @@ modules = [
 [[package]]
 org = "wso2"
 name = "websubhub.consolidator"
-version = "1.0.6"
+version = "1.0.7-SNAPSHOT"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.runtime"},
@@ -443,7 +443,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "solace"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/components/websubhub-consolidator/modules/common/observability.bal
+++ b/components/websubhub-consolidator/modules/common/observability.bal
@@ -16,4 +16,3 @@
 
 import ballerinax/jaeger as _;
 import ballerinax/prometheus as _;
-

--- a/components/websubhub/Ballerina.toml
+++ b/components/websubhub/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "wso2"
 name = "websubhub"
-version = "1.0.6"
+version = "1.0.7-SNAPSHOT"
 distribution = "2201.13.3"
 
 [build-options]

--- a/components/websubhub/Dependencies.toml
+++ b/components/websubhub/Dependencies.toml
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "avro"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -58,7 +58,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.4"
+version = "2.16.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "jaeger"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -427,7 +427,7 @@ modules = [
 [[package]]
 org = "wso2"
 name = "websubhub"
-version = "1.0.6"
+version = "1.0.7-SNAPSHOT"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jwt"},
@@ -458,7 +458,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "solace"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/components/websubhub/modules/common/observability.bal
+++ b/components/websubhub/modules/common/observability.bal
@@ -16,4 +16,3 @@
 
 import ballerinax/jaeger as _;
 import ballerinax/prometheus as _;
-


### PR DESCRIPTION
## Purpose

This PR fixes a tracer cache poisoning issue caused by module initialization order, and updates WebSubHub to `xlibb/solace` version `0.5.0`, which introduces tracing and metrics support.

**Import order / tracer cache poisoning fix**

`ballerinax/jaeger` and `ballerinax/prometheus` imports have been relocated to the lowest-level module so they are initialized before the hub's delivery/dispatch worker threads start. Previously, these worker threads could start before the tracer provider finished initializing. This caused `TracersStore` to permanently cache a no-op tracer under the default service name `"Ballerina"` for the remainder of the process lifetime, resulting in traces being dropped or misattributed from startup onward. Reordering the imports ensures the tracer provider is fully initialized before any workers can start, closing the race window.

**xlibb/solace 0.5.0 upgrade**

This version brings tracing and metrics support to the Solace connector.

* **Tracing**: for the push consumer path (`Listener`), trace context propagation is implemented, with the producer injecting W3C trace context into message properties and the listener extracting it on delivery to correlate traces across the publish/consume boundary. For the pull consumer path (`MessageConsumer.receive`/`receiveNoWait`), this is not implemented, since the span starts before the message is retrieved and no context is available to link at creation time, and this is blocked on Ballerina's tracing runtime lacking a stable span links API ( related issue - [wso2/product-integrator #1900](https://github.com/wso2/product-integrator/issues/1900) ).
* **Metrics**: closes observability gaps found when testing the connector's metrics against a live broker, where testing six deliberate error paths showed only 1 of 4 real errors being counted, and the connector had no connector-owned latency metric, no way to distinguish a disconnected session from a healthy one, and no visibility into settlements. This version fixes unreported errors across the connector's core operations and adds latency, settlement, and connectivity metrics to close those gaps.